### PR TITLE
Add ShipIt task and endpoint.

### DIFF
--- a/pollbot/api.yaml
+++ b/pollbot/api.yaml
@@ -157,6 +157,26 @@ paths:
       tags:
       - Status
 
+  /{product}/{version}/ship-it:
+    get:
+      summary: "checks version exists in ship-it.mozilla.org"
+      description: >
+        checks https://ship-it.mozilla.org/1.0/firefox.json for the
+        specific version
+      operationId: "checkShipItExistance"
+      produces:
+      - "application/json"
+      parameters:
+      - $ref: "#/parameters/product"
+      - $ref: "#/parameters/version"
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/existanceStatus"
+      tags:
+      - Status
+
   /{product}/{version}/bedrock/security-advisories:
     get:
       summary: "check security advisories have been published on mozilla.org"

--- a/pollbot/app.py
+++ b/pollbot/app.py
@@ -49,6 +49,8 @@ def get_app(loop=None):
                                 release.bedrock_download_links))
     cors.add(app.router.add_get('/v1/{product}/{version}/product-details',
                                 release.product_details))
+    cors.add(app.router.add_get('/v1/{product}/{version}/ship-it',
+                                release.ship_it))
 
     # Swagger UI and documentation
     setup_swagger(app,

--- a/pollbot/tasks/__init__.py
+++ b/pollbot/tasks/__init__.py
@@ -9,10 +9,13 @@ from pollbot import __version__ as pollbot_version
 def get_session():
     aiohttp_version = pkg_resources.get_distribution("aiohttp").version
     python_version = '.'.join([str(v) for v in sys.version_info[:3]])
-    return aiohttp.ClientSession(headers={
-        "User-Agent": "PollBot/{} aiohttp/{} python/{}".format(
-            pollbot_version, aiohttp_version, python_version)
-    })
+    return aiohttp.ClientSession(
+        conn_timeout=2,  # If the VPN is not connected, we want to fail fast.
+        read_timeout=20,
+        headers={
+            "User-Agent": "PollBot/{} aiohttp/{} python/{}".format(
+                pollbot_version, aiohttp_version, python_version)
+        })
 
 
 def heartbeat_factory(url):

--- a/pollbot/tasks/ship_it.py
+++ b/pollbot/tasks/ship_it.py
@@ -1,0 +1,19 @@
+from pollbot.exceptions import TaskError
+from pollbot.utils import build_version_id
+
+from . import get_session, heartbeat_factory
+
+
+async def ship_it_firefox_versions(product, version):
+    with get_session() as session:
+        url = 'https://ship-it.mozilla.org/json/1.0/{}_versions.json'.format(product)
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                msg = 'Ship it info not available  ({})'.format(resp.status)
+                raise TaskError(msg)
+            body = await resp.json()
+            last_release = body["LATEST_FIREFOX_VERSION"]
+            return build_version_id(last_release) >= build_version_id(version)
+
+
+heartbeat = heartbeat_factory('https://ship-it.mozilla.org/json/1.0/firefox_versions.json')

--- a/pollbot/views/release.py
+++ b/pollbot/views/release.py
@@ -5,6 +5,7 @@ from ..exceptions import TaskError
 from ..tasks.archives import archives
 from ..tasks.bedrock import release_notes, security_advisories, download_links
 from ..tasks.product_details import product_details
+from ..tasks.ship_it import ship_it_firefox_versions
 
 
 def status_response(task):
@@ -25,6 +26,12 @@ def status_response(task):
                 'status': 'error',
                 'message': str(e)
             })
+        if status is None:
+            return web.json_response({
+                "status": "error",
+                "message": "Remote service request timeout"
+            }, status=503)
+
         return web.json_response({
             "status": status and "exists" or "missing"
         })
@@ -36,3 +43,4 @@ bedrock_release_notes = status_response(release_notes)
 bedrock_security_advisories = status_response(security_advisories)
 bedrock_download_links = status_response(download_links)
 product_details = status_response(product_details)
+ship_it = status_response(ship_it_firefox_versions)

--- a/pollbot/views/utilities.py
+++ b/pollbot/views/utilities.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 import ruamel.yaml as yaml
 from aiohttp import web
 
-from pollbot.tasks import archives, bedrock, product_details
+from pollbot.tasks import archives, bedrock, product_details, ship_it
 
 
 HERE = os.path.dirname(__file__)
@@ -42,9 +42,11 @@ async def lbheartbeat(request):
 async def heartbeat(request):
     info = await asyncio.gather(archives.heartbeat(),
                                 bedrock.heartbeat(),
-                                product_details.heartbeat())
+                                product_details.heartbeat(),
+                                ship_it.heartbeat())
     status = all(info) and 200 or 503
     return web.json_response({"archive": info[0],
                               "bedrock": info[1],
-                              "product-details": info[2]},
+                              "product-details": info[2],
+                              "ship-it": info[3]},
                              status=status)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -88,6 +88,20 @@ async def test_status_response_handle_task_errors(cli):
     }
 
 
+async def test_status_response_handle_task_timeout(cli):
+    async def error_task(product, version):
+        return None
+    error_endpoint = status_response(error_task)
+    request = mock.MagicMock()
+    request.match_info = {"product": "firefox", "version": "57.0"}
+    resp = await error_endpoint(request)
+    assert json.loads(resp.body.decode()) == {
+        "status": "error",
+        "message": "Remote service request timeout",
+    }
+    assert resp.status == 503
+
+
 async def test_status_response_validates_product_name(cli):
     async def dummy_task(product, version):
         return True
@@ -178,6 +192,7 @@ async def test_heartbeat(cli):
                              "archive": True,
                              "bedrock": True,
                              "product-details": True,
+                             "ship-it": True,
                          })
 
 


### PR DESCRIPTION
Fixes #37 

ship-it is only behind the VPN.

We probably need to mock all calls to ship-it.