### PR TITLE
/contribute.json redirects to /v1/contribute.json.

### DIFF
--- a/pollbot/app.py
+++ b/pollbot/app.py
@@ -31,7 +31,8 @@ def get_app(loop=None):
     cors.add(app.router.add_get('/v1/', home.index))
 
     # Utilities
-    cors.add(app.router.add_get('/contribute.json', utilities.contribute_json))
+    cors.add(app.router.add_get('/contribute.json', utilities.contribute_redirect))
+    cors.add(app.router.add_get('/v1/contribute.json', utilities.contribute_json))
     cors.add(app.router.add_get('/v1/__api__', utilities.oas_spec))
     cors.add(app.router.add_get('/v1/__version__', utilities.version))
 

--- a/pollbot/views/utilities.py
+++ b/pollbot/views/utilities.py
@@ -35,6 +35,10 @@ async def contribute_json(request):
     return render_yaml_file("contribute.yaml")
 
 
+async def contribute_redirect(request):
+    return web.HTTPFound('/v1/contribute.json')
+
+
 async def lbheartbeat(request):
     return web.json_response({"status": "running"})
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -61,8 +61,13 @@ async def test_oas_spec(cli):
     await check_yaml_resource(cli, "/v1/__api__", "api.yaml")
 
 
+async def test_contribute_redirect(cli):
+    resp = await check_response(cli, "/contribute.json", status=302, allow_redirects=False)
+    assert resp.headers['Location'] == "/v1/contribute.json"
+
+
 async def test_contribute_json(cli):
-    await check_yaml_resource(cli, "/contribute.json", "contribute.yaml")
+    await check_yaml_resource(cli, "/v1/contribute.json", "contribute.yaml")
 
 
 async def test_home_body(cli):


### PR DESCRIPTION
Fix swagger UI for contribute.json that returns a 404: https://pollbot.dev.mozaws.net/v1/api/doc#!/Utilities/contribute