### PR TITLE
Improve Archive check for Nightly.

### DIFF
--- a/API_CHANGELOG.rst
+++ b/API_CHANGELOG.rst
@@ -5,6 +5,7 @@ API Changelog
 ----------------
 
 - Add balrog checks and endpoints.
+- Remove multiple nightly archive checks.
 
 
 1.1 (2017-09-01)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 
 - Add a task and endpoint to check the channel balrog rule (#72)
 - Validate version number to avoid calling tasks with gibberish (#92)
+- Remove archive nightly specific checks and endpoints (#95)
 
 
 0.2.1 (2017-09-06)

--- a/pollbot/api.yaml
+++ b/pollbot/api.yaml
@@ -242,40 +242,6 @@ paths:
       tags:
       - Status
 
-  /{product}/{version}/archive-date:
-    get:
-      summary: "checks if the product version package is available from the nightly latest-date archive"
-      operationId: "checkArchiveExistanceNightlyDate"
-      produces:
-      - "application/json"
-      parameters:
-      - $ref: "#/parameters/product"
-      - $ref: "#/parameters/version"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/existanceStatus"
-      tags:
-      - Status
-
-  /{product}/{version}/archive-date-l10n:
-    get:
-      summary: "checks if the product version package is available from the nightly latest-date-l10n archive"
-      operationId: "checkArchiveExistanceNightlyDateL10n"
-      produces:
-      - "application/json"
-      parameters:
-      - $ref: "#/parameters/product"
-      - $ref: "#/parameters/version"
-      responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/existanceStatus"
-      tags:
-      - Status
-
   /{product}/{version}/product-details:
     get:
       summary: "checks version exists in product-details.mozilla.org"

--- a/pollbot/app.py
+++ b/pollbot/app.py
@@ -49,10 +49,6 @@ def get_app(loop=None):
                                 release.view_get_checks))
     cors.add(app.router.add_get('/v1/{product}/{version}/archive',
                                 release.archive, name="archive"))
-    cors.add(app.router.add_get('/v1/{product}/{version}/archive-date',
-                                release.archive_date, name="archive-date"))
-    cors.add(app.router.add_get('/v1/{product}/{version}/archive-date-l10n',
-                                release.archive_date_l10n, name="archive-date-l10n"))
     cors.add(app.router.add_get('/v1/{product}/{version}/bedrock/release-notes',
                                 release.bedrock_release_notes, name="release-notes"))
     cors.add(app.router.add_get('/v1/{product}/{version}/bedrock/security-advisories',

--- a/pollbot/tasks/archives.py
+++ b/pollbot/tasks/archives.py
@@ -1,6 +1,5 @@
-from functools import partial
 from pollbot.exceptions import TaskError
-from pollbot.utils import (build_version_id, Channel, Status, get_version_channel,
+from pollbot.utils import (build_version_id, Channel, get_version_channel,
                            get_version_from_filename)
 from . import get_session, heartbeat_factory, build_task_response
 
@@ -9,25 +8,8 @@ async def archives(product, version):
     with get_session() as session:
         channel = get_version_channel(version)
         if channel is Channel.NIGHTLY:
-            return await archives_date_l10n(product, version)
-        else:
-            url = 'https://archive.mozilla.org/pub/{}/releases/{}/'.format(product, version)
-            async with session.get(url) as resp:
-                if resp.status >= 500:
-                    msg = 'Archive CDN not available (HTTP {})'.format(resp.status)
-                    raise TaskError(msg)
-                status = resp.status < 400
-                exists_message = "An archive for version {} exists at {}".format(version, url)
-                missing_message = ("No archive found for this version number at "
-                                   "https://archive.mozilla.org/pub/{}/releases/".format(product))
-                return build_task_response(status, url, exists_message, missing_message)
-
-
-async def check_nightly_archives(url, product, version):
-    with get_session() as session:
-        channel = get_version_channel(version)
-        url = url.format(product)
-        if channel is Channel.NIGHTLY:
+            url = 'https://archive.mozilla.org/pub/{}/nightly/latest-mozilla-central-l10n/'.format(
+                product)
             async with session.get(url, headers={"Accept": "application/json"}) as resp:
                 if resp.status != 200:
                     status = False
@@ -44,17 +26,17 @@ async def check_nightly_archives(url, product, version):
                 exists_message = "The archive exists at {}".format(url)
                 missing_message = "No archive found at {}".format(url)
                 return build_task_response(status, url, exists_message, missing_message)
-
-        return build_task_response(
-            status=Status.MISSING,
-            link=url,
-            message="No archive-date checks for {} releases".format(channel.value.lower()))
-
-
-archives_date = partial(check_nightly_archives,
-                        'https://archive.mozilla.org/pub/{}/nightly/latest-date/')
-archives_date_l10n = partial(check_nightly_archives,
-                             'https://archive.mozilla.org/pub/{}/nightly/latest-date-l10n/')
+        else:
+            url = 'https://archive.mozilla.org/pub/{}/releases/{}/'.format(product, version)
+            async with session.get(url) as resp:
+                if resp.status >= 500:
+                    msg = 'Archive CDN not available (HTTP {})'.format(resp.status)
+                    raise TaskError(msg)
+                status = resp.status < 400
+                exists_message = "An archive for version {} exists at {}".format(version, url)
+                missing_message = ("No archive found for this version number at "
+                                   "https://archive.mozilla.org/pub/{}/releases/".format(product))
+                return build_task_response(status, url, exists_message, missing_message)
 
 
 heartbeat = heartbeat_factory('https://archive.mozilla.org/pub/firefox/releases/')

--- a/pollbot/views/release.py
+++ b/pollbot/views/release.py
@@ -2,7 +2,7 @@ import logging
 from aiohttp import web
 from collections import OrderedDict
 
-from ..tasks.archives import archives, archives_date, archives_date_l10n
+from ..tasks.archives import archives
 from ..tasks import balrog
 from ..tasks.bedrock import release_notes, security_advisories, download_links, get_releases
 from ..tasks.product_details import product_details, devedition_and_beta_in_sync
@@ -28,8 +28,6 @@ def status_response(task):
 
 
 archive = status_response(archives)
-archive_date = status_response(archives_date)
-archive_date_l10n = status_response(archives_date_l10n)
 bedrock_release_notes = status_response(release_notes)
 bedrock_security_advisories = status_response(security_advisories)
 bedrock_download_links = status_response(download_links)
@@ -46,8 +44,6 @@ async def view_get_releases(request, product):
 
 
 CHECKS_TITLE = {
-    "archive-date": "Archive Date",
-    "archive-date-l10n": "Archive Date l10n",
     "archive": "Archive Release",
     "release-notes": "Release notes",
     "security-advisories": "Security advisories",
@@ -60,9 +56,7 @@ CHECKS_TITLE = {
 
 CHECKS = OrderedDict(
     sorted({
-        "archive-date": [Channel.NIGHTLY],
-        "archive-date-l10n": [Channel.NIGHTLY],
-        "archive": [Channel.ESR, Channel.RELEASE, Channel.BETA],
+        "archive": [Channel.ESR, Channel.RELEASE, Channel.BETA, Channel.NIGHTLY],
         "release-notes": [Channel.ESR, Channel.RELEASE, Channel.BETA, Channel.NIGHTLY],
         "security-advisories": [Channel.ESR, Channel.RELEASE],
         "download-links": [Channel.ESR, Channel.RELEASE, Channel.BETA, Channel.NIGHTLY],

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -103,7 +103,7 @@ class DeliveryTasksTest(asynctest.TestCase):
         assert received["status"] == Status.MISSING.value
 
     async def test_archives_tasks_returns_true_if_file_exists_nightly(self):
-        url = "https://archive.mozilla.org/pub/firefox/nightly/latest-date-l10n/"
+        url = "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/"
         body = {
             "files": [
                 {
@@ -143,7 +143,7 @@ class DeliveryTasksTest(asynctest.TestCase):
         assert received["status"] == Status.EXISTS.value
 
     async def test_archives_tasks_returns_false_if_absent_for_nightly(self):
-        url = 'https://archive.mozilla.org/pub/firefox/nightly/latest-date-l10n/'
+        url = 'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/'
         self.mocked.get(url, status=404)
 
         received = await archives('firefox', '57.0a1')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -192,9 +192,7 @@ async def test_get_checks_for_nightly(cli):
         "version": "57.0a1",
         "channel": "nightly",
         "checks": [
-            {"url": "http://localhost/v1/firefox/57.0a1/archive-date", "title": "Archive Date"},
-            {"url": "http://localhost/v1/firefox/57.0a1/archive-date-l10n",
-             "title": "Archive Date l10n"},
+            {"url": "http://localhost/v1/firefox/57.0a1/archive", "title": "Archive Release"},
             {"url": "http://localhost/v1/firefox/57.0a1/balrog-rules",
              "title": "Balrog update rules"},
             {"url": "http://localhost/v1/firefox/57.0a1/bedrock/download-links",
@@ -279,37 +277,12 @@ async def test_get_checks_response_validates_product_name(cli):
 
 
 # This is currently a functional test.
-async def test_release_archive_date(cli):
-    await check_response(cli, "/v1/firefox/57.0a1/archive-date", body={
+async def test_nightly_archive(cli):
+    await check_response(cli, "/v1/firefox/57.0a1/archive", body={
         "status": Status.EXISTS.value,
         "message": "The archive exists at "
-        "https://archive.mozilla.org/pub/firefox/nightly/latest-date/",
-        "link": "https://archive.mozilla.org/pub/firefox/nightly/latest-date/"
-    })
-
-
-async def test_release_archive_date_with_wrong_version_number(cli):
-    await check_response(cli, "/v1/firefox/56.0b1/archive-date", body={
-        "status": Status.MISSING.value,
-        "message": "No archive-date checks for beta releases",
-        "link": "https://archive.mozilla.org/pub/firefox/nightly/latest-date/"
-    })
-
-
-async def test_release_archive_date_l10n(cli):
-    await check_response(cli, "/v1/firefox/57.0a1/archive-date-l10n", body={
-        "status": Status.EXISTS.value,
-        "message": "The archive exists at "
-        "https://archive.mozilla.org/pub/firefox/nightly/latest-date-l10n/",
-        "link": "https://archive.mozilla.org/pub/firefox/nightly/latest-date-l10n/"
-    })
-
-
-async def test_release_archive_date_l10n_with_wrong_version_number(cli):
-    await check_response(cli, "/v1/firefox/56.0b1/archive-date-l10n", body={
-        "status": Status.MISSING.value,
-        "message": "No archive-date checks for beta releases",
-        "link": "https://archive.mozilla.org/pub/firefox/nightly/latest-date-l10n/"
+        "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/",
+        "link": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/"
     })
 
 


### PR DESCRIPTION
Previously we were checking for both `latest-date` and `latest-date-l10n` which appears not to be the Nightly archive that actually ships, they are instead in `archive-mozilla-central-l10n` that contains both localized and `en-US` versions.