### PR TITLE
Ignore `Copy of` telemetry search results.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ CHANGELOG
 0.4.0 (unreleased)
 ------------------
 
+- Ignore ``Copy of`` Telemetry search results (#115)
 - Deduplicate Balrog Build IDs (#116)
 
 

--- a/pollbot/tasks/telemetry.py
+++ b/pollbot/tasks/telemetry.py
@@ -23,7 +23,8 @@ async def get_query_info_from_title(session, query_title):
     async with session.get(query_url) as resp:
         body = await resp.json()
         if body:
-            return body[0]
+            body = [b for b in body if not b['name'].startswith('Copy of')]
+            return body and body[0] or None
 
 
 async def get_last_build_ids_for_nightly_version(session, version):

--- a/pollbot/tasks/telemetry.py
+++ b/pollbot/tasks/telemetry.py
@@ -23,8 +23,8 @@ async def get_query_info_from_title(session, query_title):
     async with session.get(query_url) as resp:
         body = await resp.json()
         if body:
-            body = [b for b in body if not b['name'].startswith('Copy of')]
-            return body and body[0] or None
+            body = [query for query in body if not query['name'].startswith('Copy of')]
+            return body[0] if len(body) > 0 else None
 
 
 async def get_last_build_ids_for_nightly_version(session, version):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -922,7 +922,8 @@ class DeliveryTasksTest(asynctest.TestCase):
         url = url.format(telemetry.TELEMETRY_SERVER)
         self.mocked.get(url, status=200, body=json.dumps([{
             "latest_query_data_id": 5678,
-            "id": 40197
+            "id": 40197,
+            "name": "Uptake Firefox NIGHTLY 57.0a1 20170920"
         }]))
 
         url = '{}/api/query_results/5678'.format(telemetry.TELEMETRY_SERVER)
@@ -937,6 +938,49 @@ class DeliveryTasksTest(asynctest.TestCase):
         assert received["message"] == ("Telemetry uptake for version 57.0a1 "
                                        "(20170920220431, 20170920111019, 20170920100426) "
                                        "is 0.45% (19,074/42,088)")
+
+    async def test_telemetry_update_uptake_tasks_should_ignore_copied_queries(self):
+        url = '{}/api/queries/{}'
+        url = url.format(telemetry.TELEMETRY_SERVER, telemetry.NIGHTLY_BUILD_IDS["57.0a1"])
+        self.mocked.get(url, status=200, body=json.dumps({
+            "latest_query_data_id": 1234
+        }))
+
+        url = '{}/api/query_results/1234'.format(telemetry.TELEMETRY_SERVER)
+        self.mocked.get(url, status=200, body=json.dumps({
+            "query_result": {"data": {"rows": [
+                {"build_id": "20170920220431"},
+                {"build_id": "20170920111019"},
+                {"build_id": "20170920100426"},
+                {"build_id": "20170919220202"},
+                {"build_id": "20170919110626"}
+            ]}}
+        }))
+
+        url = "{}/api/queries/search?q=Uptake+Firefox+NIGHTLY+57.0a1+20170920&include_drafts=true"
+        url = url.format(telemetry.TELEMETRY_SERVER)
+        self.mocked.get(url, status=200, body=json.dumps([{
+            "latest_query_data_id": 123456789,
+            "id": 40198,
+            "name": "Copy of (#40197) Uptake Firefox NIGHTLY 57.0a1 20170920"
+        }, {
+            "latest_query_data_id": 5678,
+            "id": 40197,
+            "name": "Uptake Firefox NIGHTLY 57.0a1 20170920"
+        }]))
+
+        url = '{}/api/query_results/5678'.format(telemetry.TELEMETRY_SERVER)
+        self.mocked.get(url, status=200, body=json.dumps({
+            "query_result": {"data": {"rows": [
+                {"ratio": 0.65432, "updated": 27236, "total": 42088}
+            ]}}
+        }))
+
+        received = await telemetry.update_parquet_uptake('firefox', '57.0a1')
+        assert received["status"] == Status.EXISTS.value
+        assert received["message"] == ("Telemetry uptake for version 57.0a1 "
+                                       "(20170920220431, 20170920111019, 20170920100426) "
+                                       "is 0.65% (27,236/42,088)")
 
     async def test_telemetry_update_uptake_tasks_returns_exists_for_high_nightly_uptake(self):
         url = '{}/api/queries/{}'
@@ -960,7 +1004,8 @@ class DeliveryTasksTest(asynctest.TestCase):
         url = url.format(telemetry.TELEMETRY_SERVER)
         self.mocked.get(url, status=200, body=json.dumps([{
             "latest_query_data_id": 5678,
-            "id": 40197
+            "id": 40197,
+            "name": "Uptake Firefox NIGHTLY 57.0a1 20170920"
         }]))
 
         url = '{}/api/query_results/5678'.format(telemetry.TELEMETRY_SERVER)
@@ -998,7 +1043,8 @@ class DeliveryTasksTest(asynctest.TestCase):
         url = url.format(telemetry.TELEMETRY_SERVER)
         self.mocked.get(url, status=200, body=json.dumps([{
             "latest_query_data_id": 5678,
-            "id": 40197
+            "id": 40197,
+            "name": "Uptake Firefox NIGHTLY 57.0a1 20170920"
         }]))
         url = '{}/api/query_results/5678'.format(telemetry.TELEMETRY_SERVER)
         self.mocked.get(url, status=404)
@@ -1012,7 +1058,8 @@ class DeliveryTasksTest(asynctest.TestCase):
         url = url.format(telemetry.TELEMETRY_SERVER)
         self.mocked.get(url, status=200, body=json.dumps([{
             "latest_query_data_id": 5678,
-            "id": 40197
+            "id": 40197,
+            "name": "Uptake Firefox NIGHTLY 57.0a1 20170920"
         }]))
 
         url = '{}/api/query_results/5678'.format(telemetry.TELEMETRY_SERVER)
@@ -1031,7 +1078,8 @@ class DeliveryTasksTest(asynctest.TestCase):
         url = url.format(telemetry.TELEMETRY_SERVER)
         self.mocked.get(url, status=200, body=json.dumps([{
             "latest_query_data_id": 5678,
-            "id": 40197
+            "id": 40197,
+            "name": "Uptake Firefox NIGHTLY 57.0a1 20170920"
         }]))
 
         url = '{}/api/query_results/5678'.format(telemetry.TELEMETRY_SERVER)


### PR DESCRIPTION
 Fixes #115