### PR TITLE
Add a buildhub check for nightly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 - Ignore ``Copy of`` Telemetry search results (#115)
 - Deduplicate Balrog Build IDs (#116)
 - Handle Telemetry empty results responses (#121)
+- Enable a buildhub check for Nightly (#129)
 
 
 0.3.0 (2017-09-25)

--- a/pollbot/tasks/buildhub.py
+++ b/pollbot/tasks/buildhub.py
@@ -1,18 +1,44 @@
+from urllib.parse import urlencode
+
+from pollbot.utils import Channel, get_version_channel
+
 from . import get_session, build_task_response, heartbeat_factory
+
 
 BUILDHUB_SERVER = "https://buildhub.stage.mozaws.net/v1"
 
 
 async def buildhub(product, version):
-    url = '{}/buckets/build-hub/collections/releases/records?source.product={}&target.version="{}"'
-    url = url.format(BUILDHUB_SERVER, product, version)
+    params = {
+        "source.product": product,
+        "target.version": '"%s"' % version,
+        "has_build.id": "true",
+        "_limit": 1,
+    }
+    missing_message = 'Buildhub does not contain any information about this release yet.'
+
+    channel = get_version_channel(version)
+    if channel is Channel.NIGHTLY:
+        params.update({
+            "_sort": "-build.id",
+        })
+        exists_message = 'Latest Nightly build id is {record[build][id]} for this version.'
+
+    else:
+        exists_message = 'Build id is {record[build][id]} for this release.'
+
+    url = '{}/buckets/build-hub/collections/releases/records?{}'
+    url = url.format(BUILDHUB_SERVER, urlencode(params))
 
     with get_session() as session:
         async with session.get(url) as resp:
             body = await resp.json()
             status = len(body['data']) > 0
-            exists_message = 'Buildhub contains information about this release.'
-            missing_message = 'Buildhub does not contain any information about this release yet.'
+
+            if status:
+                record = body['data'][0]
+                exists_message = exists_message.format(record=record)
+
             url = "https://mozilla-services.github.io/buildhub/?versions[0]={}&products[0]={}"
             url = url.format(version, product)
             return build_task_response(status, url, exists_message, missing_message)

--- a/pollbot/utils.py
+++ b/pollbot/utils.py
@@ -71,5 +71,5 @@ def is_valid_version(version):
         return False
 
 
-def yesterday(*, days=1):
-    return(datetime.date.today() - datetime.timedelta(days=days)).strftime('%Y-%m-%d')
+def yesterday(*, formating='%Y-%m-%d', days=1):
+    return(datetime.date.today() - datetime.timedelta(days=days)).strftime(formating)

--- a/pollbot/views/release.py
+++ b/pollbot/views/release.py
@@ -72,7 +72,7 @@ CHECKS = OrderedDict(
         "product-details": [Channel.ESR, Channel.RELEASE, Channel.BETA, Channel.NIGHTLY],
         "devedition-beta-matches": [Channel.BETA],
         "balrog-rules": [Channel.ESR, Channel.RELEASE, Channel.BETA, Channel.NIGHTLY],
-        "buildhub": [Channel.ESR, Channel.RELEASE, Channel.BETA],
+        "buildhub": [Channel.ESR, Channel.RELEASE, Channel.BETA, Channel.NIGHTLY],
         "crash-stats-uptake": [Channel.ESR, Channel.RELEASE, Channel.BETA],
         "telemetry-update-parquet-uptake": "57.0a1",
     }.items(), key=lambda t: t[0]))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -849,8 +849,9 @@ class DeliveryTasksTest(asynctest.TestCase):
         assert received['status'] == Status.INCOMPLETE.value
 
     async def test_buildhub_task_returns_missing_if_release_is_missing(self):
-        url = ('{}/buckets/build-hub/collections/releases/records'
-               '?source.product=firefox&target.version="57.0a1"').format(BUILDHUB_SERVER)
+        url = ('{}/buckets/build-hub/collections/releases/records?has_build.id=true'
+               '&source.product=firefox&_sort=-build.id&target.version="57.0a1"'
+               '&_limit=1').format(BUILDHUB_SERVER)
         self.mocked.get(url, status=200, body=json.dumps({
             'data': []
         }))
@@ -860,8 +861,9 @@ class DeliveryTasksTest(asynctest.TestCase):
                                        "about this release yet.")
 
     async def test_buildhub_task_returns_exists_if_release_was_found(self):
-        url = ('{}/buckets/build-hub/collections/releases/records'
-               '?source.product=firefox&target.version="56.0b12"').format(BUILDHUB_SERVER)
+        url = ('{}/buckets/build-hub/collections/releases/records?has_build.id=true'
+               '&source.product=firefox&target.version="56.0b12"'
+               '&_limit=1').format(BUILDHUB_SERVER)
         self.mocked.get(url, status=200, body=json.dumps({
             'data': [
                 {"last_modified": 1505713780715,
@@ -901,7 +903,7 @@ class DeliveryTasksTest(asynctest.TestCase):
 
         received = await buildhub('firefox', '56.0b12')
         assert received["status"] == Status.EXISTS.value
-        assert received["message"] == ("Buildhub contains information about this release.")
+        assert received["message"] == "Build id is 20170914024831 for this release."
 
     async def test_telemetry_update_uptake_tasks_returns_error_for_previous_nightly(self):
         received = await telemetry.update_parquet_uptake('firefox', '56.0a1')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -195,6 +195,8 @@ async def test_get_checks_for_nightly(cli):
             {"url": "http://localhost/v1/firefox/57.0a1/archive", "title": "Archive Release"},
             {"url": "http://localhost/v1/firefox/57.0a1/balrog-rules",
              "title": "Balrog update rules"},
+            {"url": "http://localhost/v1/firefox/57.0a1/buildhub",
+             "title": "Buildhub release info"},
             {"url": "http://localhost/v1/firefox/57.0a1/bedrock/download-links",
              "title": "Download links"},
             {"url": "http://localhost/v1/firefox/57.0a1/product-details",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -389,7 +389,7 @@ async def test_release_buildhub_rules(cli):
     resp = await check_response(cli, "/v1/firefox/54.0/buildhub")
     body = await resp.json()
     assert body["status"] == Status.EXISTS.value
-    assert "Buildhub contains information about this release." in body["message"]
+    assert "Build id is 20170608175746 for this release." in body["message"]
     assert body["link"] == ("https://mozilla-services.github.io/buildhub/"
                             "?versions[0]=54.0&products[0]=firefox")
 


### PR DESCRIPTION
- [x] Update `API_CHANGELOG.rst`
- [x] Update `CHANGELOG.rst` 
- [x] Update `pollbot/api.yaml`
- [x] Create your task in `pollbot/tasks`
- [x] Make sure a heartbeat exists for this service
- [x] Create the view in `pollbot/views/release.py`
- [x] Add the new endpoints in `pollbot/app.py`
- [x] Fix tests, flake8 and coverage
