### PR TITLE
Fix ESR test_esr_crash_stats_uptake

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -501,11 +501,11 @@ async def test_beta_partner_repacks(cli):
 
 
 async def test_esr_crash_stats_uptake(cli):
-    resp = await check_response(cli, "/v1/firefox/52.7.3esr/crash-stats/uptake")
+    resp = await check_response(cli, "/v1/firefox/52.7.4esr/crash-stats/uptake")
     body = await resp.json()
     assert body['status'] == Status.EXISTS.value
     assert body['link'].startswith("https://crash-stats.mozilla.com/api/ADI/")
-    assert body['message'].startswith("Crash-Stats uptake for version 52.7.3esr is")
+    assert body['message'].startswith("Crash-Stats uptake for version 52.7.4esr is")
 
 
 async def test_release_crash_stats_uptake(cli):


### PR DESCRIPTION
The version of ESR hard coded into the tests just had to be updated.  It'll probably happen again sometime in the future. 🤷‍♂️ 