### PR TITLE
Update ESR crash stat uptake test to accept INCOMPLETE or EXIST status

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -501,11 +501,11 @@ async def test_beta_partner_repacks(cli):
 
 
 async def test_esr_crash_stats_uptake(cli):
-    resp = await check_response(cli, "/v1/firefox/52.7.3esr/crash-stats/uptake")
+    resp = await check_response(cli, "/v1/firefox/52.7.4esr/crash-stats/uptake")
     body = await resp.json()
     assert body['status'] == Status.EXISTS.value
     assert body['link'].startswith("https://crash-stats.mozilla.com/api/ADI/")
-    assert body['message'].startswith("Crash-Stats uptake for version 52.7.3esr is")
+    assert body['message'].startswith("Crash-Stats uptake for version 52.7.4esr is")
 
 
 async def test_release_crash_stats_uptake(cli):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -503,7 +503,7 @@ async def test_beta_partner_repacks(cli):
 async def test_esr_crash_stats_uptake(cli):
     resp = await check_response(cli, "/v1/firefox/52.7.4esr/crash-stats/uptake")
     body = await resp.json()
-    assert body['status'] == Status.EXISTS.value
+    assert body['status'] in (Status.EXISTS.value, Status.INCOMPLETE.value)
     assert body['link'].startswith("https://crash-stats.mozilla.com/api/ADI/")
     assert body['message'].startswith("Crash-Stats uptake for version 52.7.4esr is")
 


### PR DESCRIPTION
This test should be fine if the api returns `status:incomplete` or `status:exists`.  The data changes in crash stats and we shouldn't always expect it to just be `status:exists`