### PR TITLE
Update version.json file with proper build URL in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,13 @@ jobs:
       - run:
           name: Create version.json
           command: |
-            make version-file
+            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "$CIRCLE_SHA1" \
+            "`git describe --always --tag`" \
+            "$CIRCLE_PROJECT_USERNAME" \
+            "$CIRCLE_PROJECT_REPONAME" \
+            "$CIRCLE_BUILD_URL" > version.json
 
       - store_artifacts:
           path: version.json


### PR DESCRIPTION
Seems the previous PR #224 was a fail: using the Makefile made the `build` be filled with "manual build". Which obviously is wrong.

So this reverts using the Makefile `version-file` target, and instead simply fix the `git describe` options. This should do the trick. Hopefully.