### PR TITLE
main summary uptake returns an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ __pycache__/
 .coverage
 .tox/
 .pytest_cache/
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .coverage
 .tox/
 .pytest_cache/
+.vscode

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ CHANGELOG
 1.3.0 (unreleased)
 ------------------
 
+- Telemetry: Read the paginated results instead of from the body. (#226)
 
 1.2.0 (2018-07-31)
 ------------------

--- a/pollbot/tasks/telemetry.py
+++ b/pollbot/tasks/telemetry.py
@@ -71,7 +71,7 @@ async def get_query_info_from_title(session, query_title):
         if body:
             if 'message' in body:
                 raise TaskError("STMO: {}".format(body['message']))
-            body = [query for query in body
+            body = [query for query in body['results']
                     if not query['name'].startswith('Copy of') and
                     query['user']['id'] == int(TELEMETRY_USER_ID)]
             return body[0] if len(body) > 0 else None


### PR DESCRIPTION
Fixes #226


Now I get this:

```bash
▶ curl http://localhost:8000/v1/devedition/63.0b2/telemetry/main-summary-uptake | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   121  100   121    0     0    105      0  0:00:01  0:00:01 --:--:--   105
{
  "status": "incomplete",
  "message": "Query still processing.",
  "link": "https://sql.telemetry.mozilla.org/queries/59323"
}
```

Before, I got this:

```bash
▶ curl  http://localhost:8000/v1/devedition/63.0b2/telemetry/main-summary-uptake | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    65  100    65    0     0     57      0  0:00:01  0:00:01 --:--:--    57
{
  "status": "error",
  "message": "string indices must be integers"
}
```

Fun fact, if you run that curl error, which does indeed trigger a `TypeError` the HTTP return code is still 200 OK. 