### PR TITLE
devedition tags aren't firefox tags

### DIFF
--- a/pollbot/tasks/bedrock.py
+++ b/pollbot/tasks/bedrock.py
@@ -19,10 +19,11 @@ async def release_notes(product, full_version):
     elif channel is Channel.ESR:
         version = re.sub('esr$', '', full_version)
 
-    if product == 'devedition':
-        product = 'firefox'
-
-    url = 'https://www.mozilla.org/en-US/{}/{}/releasenotes/'.format(product, version)
+    # The release notes for Devedition is actually under Firefox.
+    url = 'https://www.mozilla.org/en-US/{}/{}/releasenotes/'.format(
+        'firefox' if product == 'devedition' else product,
+        version
+    )
 
     async with get_session() as session:
         async with session.get(url, allow_redirects=False) as resp:


### PR DESCRIPTION
Fixes #231

Hey @jcristau what do you think about this change?
Basically, the URL for the release notes becomes https://www.mozilla.org/en-US/firefox/64.0beta/releasenotes/ when the product is `devedition` but when it proceeds to get the locales it uses https://hg.mozilla.org/releases/mozilla-beta/raw-file/DEVEDITION_64_0b3_RELEASE/browser/locales/shipped-locales instead.

I'm honestly just dabbling. Trying to fix something I didn't build. My context is pretty low. Perhaps you can help me review this?

