### PR TITLE
modify docker file ownership to allow run-tests.sh to run pip instal…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN buildDeps=' \
     apt-get purge -y $buildDeps && \
     rm -rf /var/lib/apt/lists/* && \
     # allow run-tests.sh to run pip install successfully
-    chmod 777 /app && \
-    chmod -R 777 /app/pollbot.egg-info
+    chown pollbot:pollbot /app && \
+    chown -R pollbot:pollbot /app/pollbot.egg-info
 
 USER pollbot
 


### PR DESCRIPTION
When I merged my earlier patches, I noticed the build failed during pip install. I can reproduce the problem locally by running run-tests.sh manually in the docker shell, even on revisions prior to my recent changes. I'm open to more elegant suggestions, but this brute force approach seems to work.