### PR TITLE
Fix Thunderbird security advisories for patch level releases. #364

### DIFF
--- a/pollbot/tasks/bedrock.py
+++ b/pollbot/tasks/bedrock.py
@@ -129,7 +129,11 @@ async def security_advisories(product, version):
                     last_release = d("html").attr('data-latest-firefox')
             elif product == 'thunderbird':
                 security_product = product
-                last_release = d("html").attr('data-esr-versions')
+                last_release_h3_id = d('h3.level-heading:first').attr('id')  # thunderbird91.5, thunderbird91.6.1
+                if not last_release_h3_id.startswith('thunderbird'):
+                    msg = 'Security advisories not found for {}'.format(product)
+                    raise TaskError(msg)
+                last_release = last_release_h3_id[11:]  # Drop "thunderbird" prefix
 
             status = build_version_id(last_release) >= build_version_id(version)
             message = ("Security advisories for release were "

--- a/pollbot/tasks/bedrock.py
+++ b/pollbot/tasks/bedrock.py
@@ -129,7 +129,7 @@ async def security_advisories(product, version):
                     last_release = d("html").attr('data-latest-firefox')
             elif product == 'thunderbird':
                 security_product = product
-                last_release_h3_id = d('h3.level-heading:first').attr('id')  # thunderbird91.5, thunderbird91.6.1
+                last_release_h3_id = d('h3.level-heading:first').attr('id')  # thunderbird91.6.1
                 if not last_release_h3_id.startswith('thunderbird'):
                     msg = 'Security advisories not found for {}'.format(product)
                     raise TaskError(msg)


### PR DESCRIPTION
Often times, Thunderbird will do a patch level release (eg 91.6.1) that does not
correspond to a Firefox ESR release. (Thunderbird 91.6.1 built against Firefox
91.6.0). When this happens, the security advisories check fails because it is
comparing to the Firefox version found in 'data-esr-versions'.

To get around this without changing the HTML of the advisories page, the id
attribute of the first 'Fixed in Thunderbird XX.X' header element is used.
